### PR TITLE
Release 0.0.2 - critical bug fixes

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -25,6 +25,9 @@ jobs:
       with:
         python-version: '3.7'
 
+    - name: Build the distribution
+      run: python setup.py sdist
+
     # Publishes the OwnCA new version in PyPi
     - name: Publish OnwCA to PyPI
       uses: pypa/gh-action-pypi-publish@master

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -17,18 +17,17 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
+    # prepare the python requirements
     steps:
-    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v1
       with:
         python-version: '3.7'
 
+    # Publishes the OwnCA new version in PyPi
     - name: Build the distribution
       run: python setup.py sdist
 
-    # Publishes the OwnCA new version in PyPi
     - name: Publish OnwCA to PyPI
       uses: pypa/gh-action-pypi-publish@master
       with:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Basically in this three lines steps:
  2. Created a new CA named as *Corp CA* that uses ```/opt/CA``` as CA storage
     for certificates, keys etc.
  3. Create a signed certificates by *Corp CA* server *www.mycorp.com*, 
- the files are also stored in ```/opt/CA/certs/mycorp.com```.
+ the files are also stored in ```/opt/CA/certs/www.example.com```.
  
     ```pycon
      >>> example_com.cert

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,7 +21,7 @@ Basically in this three lines steps:
 
 1. Imported the ownca Certificate Authority library
 2. Created a new CA named as *Corp CA* that uses ``/opt/CA`` as CA storage for certificates, keys etc.
-3. Create a signed certificates by *Corp CA* server *www.mycorp.com*, the files are also stored in ``/opt/CA/certs/mycorp.com``.
+3. Create a signed certificates by *Corp CA* server *www.mycorp.com*, the files are also stored in ``/opt/CA/certs//www.example.com``.
 
    .. code-block:: python
 

--- a/ownca/__version__.py
+++ b/ownca/__version__.py
@@ -7,7 +7,7 @@ Copyright (c) 2018, 2019 Kairo de Araujo
 __title__ = "ownca"
 __description__ = "Python Own Certificate Authority"
 __url__ = "https://github.com/OwnCA/ownca"
-__version__ = "0.0.1"
+__version__ = "0.0.2"
 __author__ = "Kairo de Araujo"
 __author_email__ = "kairo@dearaujo.nl"
 __license__ = "Apache 2.0"

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,10 @@ from setuptools.command.test import test as TestCommand
 
 here = os.path.abspath(os.path.dirname(__file__))
 
+packages = ["ownca", "ownca/crypto"]
+requires = ["cryptography>=2.8", "voluptuous>=0.11.7"]
+test_requirements = ["pytest>=3"]
+about = {}
 
 class PyTest(TestCommand):
     user_options = [("pytest-args=", "a", "Arguments to pass into py.test")]
@@ -41,17 +45,9 @@ if sys.argv[-1] == "publish":
     os.system("twine upload dist/*")
     sys.exit()
 
-packages = ["ownca"]
-
-requires = ["cryptography>=2.8"]
-test_requirements = ["pytest>=3"]
-
-about = {}
 with open(os.path.join(here, "ownca", "__version__.py"), "r", "utf-8") as f:
     exec(f.read(), about)
 
-print(os.getcwd())
-print("#" * 80)
 with open("README.md", "r", "utf-8") as f:
     readme = f.read()
 
@@ -91,7 +87,7 @@ setup(
     tests_require=test_requirements,
     extras_require={},
     project_urls={
-        # 'Documentation': 'https://ownca.readthedocs.io',
-        "Source": "https://github.com/kairoaraujo/ownca"
+        "Documentation": "https://ownca.readthedocs.io",
+        "Source": "https://github.com/OwnCa/ownca"
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ requires = ["cryptography>=2.8", "voluptuous>=0.11.7"]
 test_requirements = ["pytest>=3"]
 about = {}
 
+
 class PyTest(TestCommand):
     user_options = [("pytest-args=", "a", "Arguments to pass into py.test")]
 


### PR DESCRIPTION
- Fixed issues in setup.py that breaks the funcionality
  . Missed internal crypto package
  . Voluptuous declared as mandatory dependency
  . Minor: Documentation link to readthedocs.io

- Fixed documentation example

- Fixed the CI/CD to publish new releases