### PR TITLE
Implementation of Intermediate CA

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -29,12 +29,12 @@ jobs:
 
     # Runs Python tests
     - name: Run Python tests
-      run: make py37-tests
+      run: make all-tests
 
     # Uploads the coverage
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       with:
-        flags: unittests
+        flags: all-tests
         name: coverage
         fail_ci_if_error: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,19 +29,15 @@ jobs:
 
     # Runs Python tests
     - name: Run Python tests
-      run: make py37-tests
+      run: make all-tests
 
     # Uploads the coverage
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       with:
-        flags: unittests
+        flags: all-tests
         name: coverage
         fail_ci_if_error: true
-
-    # Run integration tests:
-    - name: Run Integration tests
-      run: make integration-tests
 
     # Docs
     - name: Install docs dependecies

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ dist
 htmlcov/
 ownca.egg-info/
 .DS_Store
+CA_test*
+ICA_test*

--- a/Makefile
+++ b/Makefile
@@ -15,16 +15,17 @@ py36-tests:
 
 py37-tests:
 	tox -re py37,pep8
-	coverage xml -i
-	coverage html -i
 
 py38-tests:
 	tox -re py38,pep8
-	coverage xml -i
-	coverage html -i
 
 integration-tests:
 	tox -re integrations
+
+all-tests:
+	tox -re all_tests
+	coverage xml -i
+	coverage html -i
 
 publish-test:
 	pip install 'twine>=1.5.0'

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,6 +3,9 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
+.. toctree::
+   :maxdepth: 2
+
 Python Own Certificate Authority (ownca)
 ========================================
 
@@ -48,6 +51,40 @@ Code example:
 
 It will create the CA files in in ``/opt/CA``.
 
+Creating an Intermediate Certificate Authority
+..............................................
+
+If a Certificate Authority (CA) needs to be Intermediate, it means the certificate needs to
+be signed by another CA, you can create that using the option ``intermendiate=True``.
+
+This action will generate only the Certificate Signing Request (CSR). Given the csr to
+the Root CA to be signed and having the certificate file, it needs to be added to the
+``ca_storage`` folder  as ``ca.crt`` and after that can be used.
+
+Code example:
+
+.. code-block:: python
+
+   >>> from ownca import CertificateAuthority
+   >>> ica_corp = CertificateAuthority(ca_storage='/opt/corp_CA', common_name='Corp CA', intermediate=True)
+   >>> ica_corp.csr_bytes
+   b'-----BEGIN CERTIFICATE REQUEST-----\nMIICijCCAXICAQAwEjEQMA4GA1UEAwwHQ29ycCBDQTCCASIwDQYJKoZIhvcNAQEB\n
+   BQADggEPADCCAQoCggEBANErvwkteBXe0PybgWT7Su3Bduig/73Y75kEOzz+Ph4G\nz3a4GEG6Gowgb5TXBpPMp6JVqo7uiSqpOV9f8SJW21CWCGu518Sit5BRFJ4wFf3P\nzEtffb1i7fMr9H2JqjXVyQnVdrIAicWLJo3uF1P5RI5fm8tk5Cq1jRk/2CdfU3nP\n6UANjoE9FAVT1tA2F84TVuGlKBXvsF8OJcCU+HoQhy9suMiTJikaK5Qeti+JBvrZ\nfbijLk8L4u1cUYVVCAzFH+xtwg3TGeH02OmlybJKkm63cre4ixdSNm6AS+o456Mb\nIKn8ksja7orH9lYyocxaitUax0b3iHNPsRFF/M0Q8XsCAwEAAaAzMDEGCSqGSIb3\nDQEJDjEkMCIwEgYDVR0RBAswCYIHQ29ycCBDQTAMBgNVHRMEBTADAQH/MA0GCSqG\nSIb3DQEBCwUAA4IBAQAu9OYSeZMrJZFXrBLqdv60STmyRx+s2/7cq9khOMdayItu\n/kUAw0EIEoB3+uCRm4tvRrZeK2rgDKp4InyJ3cCPMcU02H84OOHen1V3H9WWUEBP\nuxkecQiFpGLzj/gisFjqGOuV/PzeuB/VhfiCJm7tG0PVK9n/JzZ1WBVL9u3GxDHY\n37328J7GniD4XDidevMY/3Gq+lZI9X/OHMSIMh2Q12FG/Ol8mBVdksp4gDbNs98D\nctzfHrmGBTF/f94JX/p94xerjp3NvcAIkzrm9Tfa05BDfpq8RsGgvPAZo4S8Hphz\nKHokUqabqsIC76VBMDFTb6GU3Vv80nBYTN+LrXmr\n-----END CERTIFICATE REQUEST-----\n'
+
+.. note::
+
+   Note that this Intermediate CA is not ready to be used, certificate file is missing.
+
+.. code-block:: python
+
+   >>> ica_corp.issue_certificate('qa.dev.ownca.org')
+   Traceback (most recent call last):
+   ...
+   ownca.exceptions.OwnCAIntermediate: Intermediate Certificate Authority has not a signed certificate file in CA Storage
+
+Is necessary get the certificate signed from the CA to have this Intermediate CA ready.
+Add the certificate to ``ca_storage`` folder  as ``ca.crt``.
+
 Available methods
 .................
 
@@ -55,14 +92,19 @@ The Certificate Authority has built in methods such as
 
 - `common_name <ownca.html#ownca.ownca.CertificateAuthority.common_name>`_
 - `cert <ownca.html#ownca.ownca.CertificateAuthority.cert>`_
-- `certificates <ownca.html#ownca.ownca.CertificateAuthority.certificates>`_
 - `cert_bytes <ownca.html#ownca.ownca.CertificateAuthority.cert_bytes>`_
+- `certificates <ownca.html#ownca.ownca.CertificateAuthority.certificates>`_
+- `csr <ownca.html#ownca.ownca.CertificateAuthority.csr>`_
+- `csr_bytes <ownca.html#ownca.ownca.CertificateAuthority.csr_bytes>`_
 - `key <ownca.html#ownca.ownca.CertificateAuthority.key>`_
 - `key_bytes <ownca.html#ownca.ownca.CertificateAuthority.key_bytes>`_
 - `public_key <ownca.html#ownca.ownca.CertificateAuthority.public_key>`_
 - `public_key_bytes <ownca.html#ownca.ownca.CertificateAuthority.public_key_bytes>`_
 - `hash_name <ownca.html#ownca.ownca.CertificateAuthority.hash_name>`_
+- `issue_certificate <ownca.html#ownca.ownca.CertificateAuthority.issue_certificate>`_
+- `revoke_certificate <ownca.html#ownca.ownca.CertificateAuthority.revoke_certificate>`_
 - `status <ownca.html#ownca.ownca.CertificateAuthority.status>`_
+- `sign_csr <ownca.html#ownca.ownca.CertificateAuthority.sign_csr>`_
 
 See `CertificateAuthority <ownca.html#ownca.ownca.CertificateAuthority>`_ for
 more details.
@@ -145,6 +187,8 @@ The Certificate Authority has built in methods such as
 - `common_name <ownca.html#ownca.ownca.HostCertificate.common_name>`_
 - `cert <ownca.html#ownca.ownca.HostCertificate.cert>`_
 - `cert_bytes <ownca.html#ownca.ownca.HostCertificate.cert_bytes>`_
+- `csr <ownca.html#ownca.ownca.HostCertificate.csr>`_
+- `csr_bytes <ownca.html#ownca.ownca.HostCertificate.csr_bytes>`_
 - `key <ownca.html#ownca.ownca.HostCertificate.key>`_
 - `key_bytes <ownca.html#ownca.ownca.HostCertificate.key_bytes>`_
 - `public_key <ownca.html#ownca.ownca.HostCertificate.public_key>`_
@@ -181,9 +225,9 @@ The motivation
 
 The ownca was created in 2017 as a group of scripts to manage certificates, in
 2018 it was moved to a very simple library (mostly hardcoded actions) and now
-in 2019 was decide to open and be a library that could help others.
+2019 was decide to open and be a library that could help others.
 
-Basically, ownca uses the powerful library http://cryptography.io .
+Basically, OwnCA uses the powerful library http://cryptography.io .
 
 
 .. toctree::

--- a/ownca/_constants.py
+++ b/ownca/_constants.py
@@ -11,6 +11,7 @@ CA_CERT = "ca.crt"
 CA_KEY = f"{CA_PRIVATE_DIR}/ca_key.pem"
 CA_PUBLIC_KEY = "ca_key.pub"
 CA_CRL = "ca.crl"
+CA_CSR = "ca.csr"
 
 # Supported OIDS
 OIDS = [

--- a/ownca/crypto/certs.py
+++ b/ownca/crypto/certs.py
@@ -234,7 +234,7 @@ def issue_csr(key=None, common_name=None, dns_names=None, oids=None):
     return _valid_csr(csr)
 
 
-def ca_sign_csr(ca_cert, ca_key, csr, key, maximum_days=None):
+def ca_sign_csr(ca_cert, ca_key, csr, public_key, maximum_days=None):
     """
     Sign a Certificate Signing Request
 
@@ -287,8 +287,7 @@ def ca_sign_csr(ca_cert, ca_key, csr, key, maximum_days=None):
     )
     certificate = certificate.add_extension(
         extension=x509.AuthorityKeyIdentifier.from_issuer_public_key(
-            # TODO: Do not ask for the key but Public Key only.
-            key.public_key()
+            public_key
         ),
         critical=False,
     )

--- a/ownca/exceptions.py
+++ b/ownca/exceptions.py
@@ -11,6 +11,11 @@ class OwnCAInconsistentData(Exception):
     pass
 
 
+class OwnCAIntermediate(Exception):
+    """CA is a Intermediate Certificate Authority missing certificate file"""
+    pass
+
+
 class OwnCAInvalidFiles(Exception):
     """CA Files are inconsistent."""
 

--- a/tests/integrations/conftest.py
+++ b/tests/integrations/conftest.py
@@ -6,7 +6,9 @@ Copyright (c) 2018-2020 Kairo de Araujo
 import os
 import shutil
 
+
 CA_STORAGE = "CA_test"
+ICA_STORAGE = "ICA_test"
 CA_COMMON_NAME = "ownca.org"
 CA_OIDS = {
     "country_name": "BR",

--- a/tests/integrations/test_openssl.py
+++ b/tests/integrations/test_openssl.py
@@ -17,7 +17,7 @@ from tests.integrations.conftest import (
 
 
 def test_valid_cert_ca():
-    """Test if OpenSSL is able to validate the certificate against CA."""
+    """Int Test: if OpenSSL is able to validate the certificate against CA."""
 
     clean_test()
     ca = CertificateAuthority(
@@ -49,7 +49,7 @@ def test_valid_cert_ca():
 
 
 def test_validad_cert_sencond_ca():
-    """Test if OpenSSL FAILS to validate certificate against other CA"""
+    """Int Test: if OpenSSL FAILS to validate certificate against other CA"""
 
     clean_test()
     clean_test("CA_test_second")
@@ -100,7 +100,7 @@ def test_validad_cert_sencond_ca():
 
 
 def test_extension_subject_alternative_name():
-    """Test if OpenSSL gets correct Subject Alternative Name"""
+    """Int Test: if OpenSSL gets correct Subject Alternative Name"""
 
     clean_test()
     clean_test("CA_test_second")
@@ -138,7 +138,7 @@ def test_extension_subject_alternative_name():
 
 
 def test_create_certificate_and_revoke():
-    """Test if revoked certificate shows in CRL"""
+    """Int Test: if revoked certificate shows in CRL"""
 
     clean_test()
     clean_test("CA_test_second")

--- a/tests/unit/ownca/test_utils.py
+++ b/tests/unit/ownca/test_utils.py
@@ -76,7 +76,9 @@ def test_ownca_directory(mock__create_ownca_dir, mock_glob, mock_os):
         "certificate": True,
         "key": True,
         "crl": True,
+        "csr": True,
         "public_key": True,
+        "type": "Intermediate Certificate Authority"
     }
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,9 +11,13 @@ deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/dev-requirements.txt
 
 commands = coverage run -m pytest --pdb -vv tests/unit
+setenv = TEST_MODE = True
 
 [testenv:integrations]
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/dev-requirements.txt
 
 commands = coverage run -m pytest --pdb -vv tests/integrations
+
+[testenv:all_tests]
+commands = coverage run -m pytest --pdb -vv tests/unit tests/integrations


### PR DESCRIPTION
This commit implements the Intermediate CA functionality.

Creating the Intermediate CA allows to create the CA Object that
does not create directly the self signed certificate, but only the
Certificate Signature Request (CSR) to be signed by some CA and
provides the final Certificate file.

The certificate file needs to be named as ca.crt and added to
the CA Object CA Storage.
Once the file is there the ICA is ready to generate certificates.
If the certificate file is not present it will raise an exception
OwnCAIntermediate saying that the file is missing.

This feature introduces the ``CertificateAuthority`` parameter
``intermediate`` that is a bool parameter, by default False.

Also the CA Object has the properties: ``csr`` that retrives the csr
object and ``csr_bytes`` that retrieves the csr in bytes format.

Aditionally to this same object was added the method ``sign_csr`` to be
used by CA Objects (that are not intermedite) and it will generate a
certificate based in the csr, in case, this CA want to sign csr for
some intermediate CA for example.

More details were updated to the documentation.

+ Small improvements to not related features.