### PR TITLE
Switch to more portable method of constructing file system paths

### DIFF
--- a/ownca/_constants.py
+++ b/ownca/_constants.py
@@ -3,12 +3,14 @@
 """
 Copyright (c) 2018-2020 Kairo de Araujo
 """
+import os
+
 
 # CA directories and files
 CA_PRIVATE_DIR = "private"
 CA_CERTS_DIR = "certs"
 CA_CERT = "ca.crt"
-CA_KEY = f"{CA_PRIVATE_DIR}/ca_key.pem"
+CA_KEY = os.path.join(CA_PRIVATE_DIR, "ca_key.pem")
 CA_PUBLIC_KEY = "ca_key.pub"
 CA_CRL = "ca.crl"
 CA_CSR = "ca.csr"

--- a/ownca/ownca.py
+++ b/ownca/ownca.py
@@ -705,11 +705,11 @@ class CertificateAuthority:
         :rtype: list
         """
 
-        host_cert_dir = f"{self.ca_storage}/{CA_CERTS_DIR}"
+        host_cert_dir = os.path.join(self.ca_storage, CA_CERTS_DIR)
         certificate_list = list()
 
         for content in os.listdir(host_cert_dir):
-            if not os.path.isdir(f"{host_cert_dir}/{content}"):
+            if not os.path.isdir(os.path.join(host_cert_dir, content)):
                 continue
             certificate_list.append(content)
 
@@ -767,11 +767,11 @@ class CertificateAuthority:
             )
         """
 
-        private_ca_key_file = f"{self.ca_storage}/{CA_KEY}"
-        public_ca_key_file = f"{self.ca_storage}/{CA_PUBLIC_KEY}"
-        certificate_file = f"{self.ca_storage}/{CA_CERT}"
-        csr_file = f"{self.ca_storage}/{CA_CSR}"
-        crl_file = f"{self.ca_storage}/{CA_CRL}"
+        private_ca_key_file = os.path.join(self.ca_storage, CA_KEY)
+        public_ca_key_file = os.path.join(self.ca_storage, CA_PUBLIC_KEY)
+        certificate_file = os.path.join(self.ca_storage, CA_CERT)
+        csr_file = os.path.join(self.ca_storage, CA_CSR)
+        crl_file = os.path.join(self.ca_storage, CA_CRL)
 
         if self.current_ca_status is True:
             cert_data = load_cert_files(
@@ -921,12 +921,12 @@ class CertificateAuthority:
                 + f"the hostname rules r'{HOSTNAME_REGEX}'"
             )
 
-        host_cert_dir = f"{self.ca_storage}/{CA_CERTS_DIR}/{hostname}"
-        host_key_path = f"{host_cert_dir}/{hostname}.pem"
-        host_public_path = f"{host_cert_dir}/{hostname}.pub"
-        host_csr_path = f"{host_cert_dir}/{hostname}.csr"
-        host_cert_path = f"{host_cert_dir}/{hostname}.crt"
-        crl_file = f"{self.ca_storage}/{CA_CRL}"
+        host_cert_dir = os.path.join(self.ca_storage, CA_CERTS_DIR, hostname)
+        host_key_path = os.path.join(host_cert_dir, f"{hostname}.pem")
+        host_public_path = os.path.join(host_cert_dir, f"{hostname}.pub")
+        host_csr_path = os.path.join(host_cert_dir, f"{hostname}.csr")
+        host_cert_path = os.path.join(host_cert_dir, f"{hostname}.crt")
+        crl_file = os.path.join(self.ca_storage, CA_CRL)
 
         files = {
             "certificate": host_cert_path,
@@ -1013,7 +1013,7 @@ class CertificateAuthority:
         :return: host object
         :rtype: ``ownca.ownca.HostCertificate``
         """
-        host_cert_dir = f"{self.ca_storage}/{CA_CERTS_DIR}/{hostname}"
+        host_cert_dir = os.path.join(self.ca_storage, CA_CERTS_DIR, hostname)
         if not os.path.isdir(host_cert_dir):
             raise OwnCAInvalidCertificate(
                 f"The certificate does not exist for '{hostname}'."
@@ -1044,12 +1044,12 @@ class CertificateAuthority:
         if certificate.revoked:
             return None
 
-        host_cert_dir = f"{self.ca_storage}/{CA_CERTS_DIR}/{hostname}"
-        host_key_path = f"{host_cert_dir}/{hostname}.pem"
-        host_csr_path = f"{host_cert_dir}/{hostname}.csr"
-        host_public_path = f"{host_cert_dir}/{hostname}.pub"
-        host_cert_path = f"{host_cert_dir}/{hostname}.crt"
-        crl_file = f"{self.ca_storage}/{CA_CRL}"
+        host_cert_dir = os.path.join(self.ca_storage, CA_CERTS_DIR, hostname)
+        host_key_path = os.path.join(host_cert_dir, f"{hostname}.pem")
+        host_csr_path = os.path.join(host_cert_dir, f"{hostname}.csr")
+        host_public_path = os.path.join(host_cert_dir, f"{hostname}.pub")
+        host_cert_path = os.path.join(host_cert_dir, f"{hostname}.crt")
+        crl_file = os.path.join(self.ca_storage, CA_CRL)
 
         if common_name is None:
             common_name = hostname
@@ -1138,7 +1138,7 @@ class CertificateAuthority:
         csr_bytes = csr.public_bytes(
             encoding=serialization.Encoding.PEM
         )
-        host_cert_dir = f"{self.ca_storage}/{CA_CERTS_DIR}/{common_name}"
+        host_cert_dir = os.path.join(self.ca_storage, CA_CERTS_DIR, common_name)
 
         certificate = ca_sign_csr(
             self.cert, self.key, csr, csr_public_key,
@@ -1146,9 +1146,9 @@ class CertificateAuthority:
         )
 
         os.mkdir(host_cert_dir)
-        host_public_path = f"{host_cert_dir}/{common_name}.pub"
-        host_csr_path = f"{host_cert_dir}/{common_name}.csr"
-        host_cert_path = f"{host_cert_dir}/{common_name}.crt"
+        host_public_path = os.path.join(host_cert_dir, f"{common_name}.pub")
+        host_csr_path = os.path.join(host_cert_dir, f"{common_name}.csr")
+        host_cert_path = os.path.join(host_cert_dir, f"{common_name}.crt")
 
         store_file(csr_public_key_bytes, host_public_path)
 

--- a/ownca/utils.py
+++ b/ownca/utils.py
@@ -112,26 +112,27 @@ def ownca_directory(ca_storage):
     current_subdirs = glob(f"{ca_storage}/*")
 
     for ownca_subdir in ownca_subdirs:
-        if f"{ca_storage}/{ownca_subdir}" not in current_subdirs:
+        ca_storage_sub_dir = os.path.join(ca_storage, ownca_subdir)
+        if ca_storage_sub_dir not in current_subdirs:
             ownca_status["ca_home"] = "Inconsistent!"
-            _create_ownca_dir(f"{ca_storage}/{ownca_subdir}")
+            _create_ownca_dir(ca_storage_sub_dir)
 
     ownca_status["ca_home"] = ca_storage
 
-    if os.path.isfile(f"{ca_storage}/{CA_CERT}"):
+    if os.path.isfile(os.path.join(ca_storage, CA_CERT)):
         ownca_status["certificate"] = True
 
-    if os.path.isfile(f"{ca_storage}/{CA_CSR}"):
+    if os.path.isfile(os.path.join(ca_storage, CA_CSR)):
         ownca_status["csr"] = True
         ownca_status["type"] = "Intermediate Certificate Authority"
 
-    if os.path.isfile(f"{ca_storage}/{CA_CRL}"):
+    if os.path.isfile(os.path.join(ca_storage, CA_CRL)):
         ownca_status["crl"] = True
 
-    if os.path.isfile(f"{ca_storage}/{CA_KEY}"):
+    if os.path.isfile(os.path.join(ca_storage, CA_KEY)):
         ownca_status["key"] = True
 
-    if os.path.isfile(f"{ca_storage}/{CA_PUBLIC_KEY}"):
+    if os.path.isfile(os.path.join(ca_storage, CA_PUBLIC_KEY)):
         ownca_status["public_key"] = True
 
     return ownca_status


### PR DESCRIPTION
Using os.path.join() should make the file system paths compatible with Windows.
I did a quick test switching to pathlib but that broke the tests.
So this is a first step.