### PR TITLE
Use os.makedirs to create intermediate directories

### DIFF
--- a/ownca/utils.py
+++ b/ownca/utils.py
@@ -64,7 +64,7 @@ def _create_ownca_dir(ownca_dir):
         if not os.path.isdir(ownca_dir):
             os.makedirs(ownca_dir)
 
-    except (FileExistsError, OSError, FileNotFoundError) as err:
+    except (FileExistsError, OSError) as err:
         raise err
 
 

--- a/ownca/utils.py
+++ b/ownca/utils.py
@@ -62,7 +62,7 @@ def _create_ownca_dir(ownca_dir):
     """
     try:
         if not os.path.isdir(ownca_dir):
-            os.mkdir(ownca_dir)
+            os.makedirs(ownca_dir)
 
     except (FileExistsError, OSError, FileNotFoundError) as err:
         raise err
@@ -106,7 +106,7 @@ def ownca_directory(ca_storage):
     }
 
     if not os.path.isdir(ca_storage):
-        os.mkdir(ca_storage)
+        os.makedirs(ca_storage)
 
     ownca_subdirs = [CA_CERTS_DIR, CA_PRIVATE_DIR]
     current_subdirs = glob(f"{ca_storage}/*")

--- a/tests/unit/ownca/test_utils.py
+++ b/tests/unit/ownca/test_utils.py
@@ -48,18 +48,6 @@ def test__create_ownca_dir(mock_os):
 
 
 @mock.patch("ownca.utils.os")
-def test__create_ownca_dir_case_exceptions(mock_os):
-
-    exceptions = [FileExistsError, OSError, FileNotFoundError]
-    mock_os.path.isdir.return_value = False
-    mock_os.mkdir.side_effect = exceptions
-
-    for exception in exceptions:
-        with pytest.raises(exception):
-            _create_ownca_dir("test_dir")
-
-
-@mock.patch("ownca.utils.os")
 @mock.patch("ownca.utils.glob")
 @mock.patch("ownca.utils._create_ownca_dir")
 def test_ownca_directory(mock__create_ownca_dir, mock_glob, mock_os):

--- a/tests/unit/ownca/test_utils.py
+++ b/tests/unit/ownca/test_utils.py
@@ -48,6 +48,18 @@ def test__create_ownca_dir(mock_os):
 
 
 @mock.patch("ownca.utils.os")
+def test__create_ownca_dir_case_exceptions(mock_os):
+
+    exceptions = [FileExistsError, OSError]
+    mock_os.path.isdir.return_value = False
+    mock_os.makedirs.side_effect = exceptions
+
+    for exception in exceptions:
+        with pytest.raises(exception):
+            _create_ownca_dir("test_dir")
+
+
+@mock.patch("ownca.utils.os")
 @mock.patch("ownca.utils.glob")
 @mock.patch("ownca.utils._create_ownca_dir")
 def test_ownca_directory(mock__create_ownca_dir, mock_glob, mock_os):


### PR DESCRIPTION
This is just a simple change that lets people specify any number of new directories in the path for the CA storage.
