### PR TITLE
Feature/non ca certs

### DIFF
--- a/ownca/crypto/certs.py
+++ b/ownca/crypto/certs.py
@@ -200,7 +200,7 @@ def issue_cert(
     return _valid_cert(certificate)
 
 
-def issue_csr(key=None, common_name=None, dns_names=None, oids=None):
+def issue_csr(key=None, common_name=None, dns_names=None, oids=None, ca=True):
     """
     Issue a new CSR (Certificate Signing Request)
 
@@ -213,6 +213,8 @@ def issue_csr(key=None, common_name=None, dns_names=None, oids=None):
     :param oids: list of OID Objects (``cryptography.x509.oid.NameOID``)
         or None. See ``ownca.format_oids``.
     :type oids: list, required.
+    :param ca: Certificate is CA or not.
+    :type ca: bool, default True.
 
     :return: certificate sigining request object
     :rtype: ``cryptography.x509.CertificateSigningRequest``
@@ -228,7 +230,7 @@ def issue_csr(key=None, common_name=None, dns_names=None, oids=None):
     )
 
     csr_builder = csr_builder.add_extension(
-        x509.BasicConstraints(ca=True, path_length=None), critical=False
+        x509.BasicConstraints(ca=ca, path_length=None), critical=False
     )
     csr = csr_builder.sign(
         private_key=key, algorithm=hashes.SHA256(), backend=default_backend()
@@ -237,7 +239,7 @@ def issue_csr(key=None, common_name=None, dns_names=None, oids=None):
     return _valid_csr(csr)
 
 
-def ca_sign_csr(ca_cert, ca_key, csr, public_key, maximum_days=None):
+def ca_sign_csr(ca_cert, ca_key, csr, public_key, maximum_days=None, ca=True):
     """
     Sign a Certificate Signing Request
 
@@ -250,6 +252,8 @@ def ca_sign_csr(ca_cert, ca_key, csr, public_key, maximum_days=None):
     :param key: key object ``cryptography.hazmat.backends.openssl.rsa``
     :param maximum_days: number of maximum days of certificate (expiration)
     :type maximum_days: int, required, min 1 max 825.
+    :param ca: Certificate is CA or not.
+    :type ca: bool, default True.
 
     :return: certificate object
     :rtype: ``cryptography.x509.Certificate``
@@ -285,7 +289,7 @@ def ca_sign_csr(ca_cert, ca_key, csr, public_key, maximum_days=None):
         critical=True,
     )
     certificate = certificate.add_extension(
-        x509.BasicConstraints(ca=True, path_length=None),
+        x509.BasicConstraints(ca=ca, path_length=None),
         critical=True,
     )
     certificate = certificate.add_extension(

--- a/ownca/ownca.py
+++ b/ownca/ownca.py
@@ -877,6 +877,7 @@ class CertificateAuthority:
         oids=None,
         public_exponent=65537,
         key_size=2048,
+        ca=True,
     ):
         """
         Issues a new certificate signed by the CA
@@ -904,6 +905,9 @@ class CertificateAuthority:
         :type public_exponent: int, default: 65537
         :param key_size: Key size
         :type key_size: int, default: 2048
+        :param ca: Certificate is CA or not.
+        :type ca: bool, default True.
+
         :return: host object
         :rtype: ``ownca.ownca.HostCertificate``
         """
@@ -961,6 +965,7 @@ class CertificateAuthority:
                 common_name=common_name,
                 dns_names=dns_names,
                 oids=oids,
+                ca=ca,
             )
 
             store_file(
@@ -976,6 +981,7 @@ class CertificateAuthority:
                 csr,
                 key_data.public_key,
                 maximum_days=maximum_days,
+                ca=ca,
             )
             certificate_bytes = certificate.public_bytes(
                 encoding=serialization.Encoding.PEM

--- a/tests/unit/ownca/crypto/test_cert.py
+++ b/tests/unit/ownca/crypto/test_cert.py
@@ -122,15 +122,19 @@ def test_issue_csr_with_dns_names(
 
     assert isinstance(csr, classmethod)
 
+
 @mock.patch("ownca.crypto.certs._valid_csr")
 @mock.patch("ownca.crypto.certs.x509")
-def test_issue_csr_ca_false(mock_x509, mock__valid_csr, oids_sample, fake_certificate):
+def test_issue_csr_ca_false(
+    mock_x509, mock__valid_csr, oids_sample, fake_certificate
+):
     mock_x509.NameAttribute.return_value = oids_sample
     mock__valid_csr.return_value = fake_certificate
 
     csr = issue_csr(oids=["OID"], ca=False)
 
     assert isinstance(csr, classmethod)
+
 
 @mock.patch("ownca.crypto.certs._valid_csr")
 @mock.patch("ownca.crypto.certs.x509")

--- a/tests/unit/ownca/crypto/test_cert.py
+++ b/tests/unit/ownca/crypto/test_cert.py
@@ -122,6 +122,15 @@ def test_issue_csr_with_dns_names(
 
     assert isinstance(csr, classmethod)
 
+@mock.patch("ownca.crypto.certs._valid_csr")
+@mock.patch("ownca.crypto.certs.x509")
+def test_issue_csr_ca_false(mock_x509, mock__valid_csr, oids_sample, fake_certificate):
+    mock_x509.NameAttribute.return_value = oids_sample
+    mock__valid_csr.return_value = fake_certificate
+
+    csr = issue_csr(oids=["OID"], ca=False)
+
+    assert isinstance(csr, classmethod)
 
 @mock.patch("ownca.crypto.certs._valid_csr")
 @mock.patch("ownca.crypto.certs.x509")


### PR DESCRIPTION
Hey guys, seems like my last attempt at this didn't cover all bases. I've now made it possible to issue a certificate like how the readme example shows but by specifiying ca=False the certificate can be implicity trusted by the browser as long as the CA cert is trusted. 