### PR TITLE
Fix docs failing in GA

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,7 @@
 -i https://pypi.org/simple
+cryptography==3.4.8
+voluptuous==0.12.2
+
 alabaster==0.7.12
 babel==2.10.3; python_version >= '3.6'
 certifi==2022.6.15; python_version >= '3.6'


### PR DESCRIPTION
In this commit we update the packages of sphinx
and sphinx-rtd-theme to resolve a package
dependency issue that caused the building of the
docs to fail.
The docs/requirements.txt file was generated by
creating a virtual env and installing only
sphinx and sphinx-rtd-theme and the running
pipenv lock -r to get the requirements and copy
paste them into the docs/requirements.txt.

Fixes #73