### PR TITLE
Migrate setup.py to pyproject.toml

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -16,8 +16,11 @@ jobs:
       with:
         python-version: '3.9'
 
+    - name: Install requirements
+      run: python -m pip install build
+
     - name: Build the distribution
-      run: python setup.py sdist
+      run: python -m build
 
     - name: Publish distribution 📦 to PyPI
       if: startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/test_pypi.yml
+++ b/.github/workflows/test_pypi.yml
@@ -17,8 +17,11 @@ jobs:
       with:
         python-version: '3.9'
 
+    - name: Install requirements
+      run: python -m pip install build
+
     - name: Build the distribution
-      run: python setup.py sdist
+      run: python -m build
 
     - name: Publish distribution 📦 to Test PyPI
       uses: pypa/gh-action-pypi-publish@master

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,70 @@
+[build-system]
+# Minimum requirements for the build system to execute.
+requires = ["setuptools", "wheel"] # PEP 508 specifications.
+build-backend = "setuptools.build_meta"
+
+[project]
+# https://packaging.python.org/en/latest/specifications/declaring-project-metadata/
+# the only field required to be statically defined
+name = "OwnCA"
+dynamic = ["version"]
+description = "Python Own Certificate Authority"
+readme = "README.md"
+requires-python = ">=3.7"
+license = {text = "Apache 2.0"}
+keywords = ["ownca", "Certificate Authority", "CA", "certificates"]
+authors = [
+  {email = "kairo@dearaujo.nl"},
+  {name = "Kairo de Araujo"}
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Natural Language :: English",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Programming Language :: Python :: Implementation :: PyPy",
+]
+
+dependencies = [
+  "cryptography<35.0.0,>=3.4.6",
+  "voluptuous>=0.11.7",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "coverage==5.1",
+    "tox",
+    "flake8",
+    "codecov",
+    "sphinx",
+    "sphinx-rtd-theme",
+    "twine",
+    "mypy",
+    "isort",
+    "black==21.12b0",
+]
+
+[project.urls]
+documentation = "https://ownca.readthedocs.io"
+repository = "https://github.com/OwnCA/ownca"
+
+# https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html#setuptools-specific-configuration
+[tool.setuptools]
+zip-safe = false
+include-package-data = true
+license-files = ["LICENSE"]
+
+[tool.setuptools.packages.find]
+include = ["ownca*"]  # package names should match these glob patterns (["*"] by default)
+# files excluded in .whl but still there in .tar.gz
+exclude = ["tests*"]  # exclude packages matching these glob patterns (empty by default)
+
+[tool.setuptools.dynamic]
+version = {attr = "ownca.__version__.__version__"}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,8 @@
+# pip still might require a setup.py file to support ...
+# editable installs (PEP 660)
+# https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html
+# keep this file until it does
+
 [bdist_wheel]
 universal = 1
 

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,8 @@
+# pip still might require a setup.py file to support ...
+# editable installs (PEP 660)
+# https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html
+# keep this file until it does
+
 #!/usr/bin/env python
 import os
 import sys

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,10 @@
+#!/usr/bin/env python
+
 # pip still might require a setup.py file to support ...
 # editable installs (PEP 660)
 # https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html
 # keep this file until it does
 
-#!/usr/bin/env python
 import os
 import sys
 from codecs import open


### PR DESCRIPTION
Modern Python packages can contain a pyproject.toml file,
first introduced in PEP 518 and later expanded in PEP 517,
PEP 621 and PEP 660.
With this commit we prepare the pyproject.toml using
setuptools as a build-backend.

We do not remove setup.py and setup.cfg yet, since pip
still requires those files to support editable installs
(PEP 660). https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html#

We also use the Build package to build our package
before uploading to PyPI.
(while building we get a message that:
_BetaConfiguration: Support for `[tool.setuptools]` in
`pyproject.toml` is still *beta*.)

Fixes #72